### PR TITLE
Added new screenshot option "title".

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Enabling Jenkins Screenshots
 
 Jenkins screenshot attachments can be written to the report to allow for a screenshot attachment in each test failure. Simply specify a reporterOption of `spec` or `loop`. This writes a `system-out` xml element to the JUnit report, leveraging the `Publish test attachments` feature of the `JUnit Attachments Plugin`.
 
-`spec` will write the full path of the screenshot with a filename consisting of "suitename+classname+test.title+extension". `loop` pulls and sorts all screenshots with specific filename text from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled. The `imagestring` reporterOption can be used to specify what files to pull, allowing for custom screenshot naming conventions on the mocha side, otherwise it defaults to the test suite name.
+`spec` will write the full path of the screenshot with a filename consisting of "suitename+classname+test.title+extension". `title` will write the full path of the screenshot but with the parent suite and test title as the file name, space character in the title are replaced by hyphen. `loop` pulls and sorts all screenshots with specific filename text from `JUNIT_REPORT_PATH` and writes them in order according to the names of the files pulled. The `imagestring` reporterOption can be used to specify what files to pull, allowing for custom screenshot naming conventions on the mocha side, otherwise it defaults to the test suite name.
 
 Screenshot extension defaults to ".png", but can also be passed in with the `imagetype` reporterOption.
 

--- a/lib/jenkins.js
+++ b/lib/jenkins.js
@@ -109,7 +109,7 @@ function Jenkins(runner, options) {
 
     if (tests.length === 0 && currentSuite.failures > 0) {
       // Get the runnable that failed, which is a beforeAll or beforeEach
-      tests = [currentSuite.suite.ctx.runnable()];
+    	tests = [currentSuite.suite.ctx.runnable()];
     }
 
     tests.forEach(function(test) {
@@ -128,36 +128,39 @@ function Jenkins(runner, options) {
         writeString('\n</failure>\n');
 
         //screenshot name is either pulled in sorted order from junit_report_path
+        //or set as simple combined suite and test title with space replaced by hyphen
         //or set as suitename + classname + title, then written with Jenkins ATTACHMENT tag
         if (options.screenshots) {
           var screenshotDir = path.join(process.cwd(), options.junit_report_path);
           if (options.screenshots == 'loop') {
             screenshot = path.join(screenshotDir, screenshots[screenshotIndex]);
             screenshotIndex++;
+          } else if (options.screenshots == 'title') {
+            screenshot = path.join(screenshotDir, (test.parent.title+"_"+test.title).replace(/\s/g, '-') + "." + imagetype);
           } else {
             screenshot = path.join(screenshotDir, imagestring +
-                getClassName(test, currentSuite.suite) + test.title + "." + imagetype);
+          		getClassName(test, currentSuite.suite) + test.title + "." + imagetype);
           }
-          writeString('<system-out>\n');
-          writeString('[[ATTACHMENT|' + screenshot + ']]\n');
-          writeString('</system-out>\n');
         }
       } else if(test.state === undefined) {
         writeString('<skipped/>\n');
       }
 
-      if (test.logEntries && test.logEntries.length) {
+      if (test.logEntries && test.logEntries.length || typeof screenshot != 'undefined') {
         writeString('<system-out><![CDATA[');
-        test.logEntries.forEach(function (entry) {
-          var outstr = util.format.apply(util, entry) + '\n';
-          outstr = removeInvalidXmlChars(outstr);
-          // We need to escape CDATA ending tags inside CDATA
-          outstr = outstr.replace(/]]>/g, ']]]]><![CDATA[>')
-          writeString(outstr);
-        });
-        writeString(']]></system-out>\n');
-      }
-
+        if (test.logEntries && test.logEntries.length) {
+		    	test.logEntries.forEach(function (entry) {
+	          var outstr = util.format.apply(util, entry) + '\n';
+	          outstr = removeInvalidXmlChars(outstr);
+	          // We need to escape CDATA ending tags inside CDATA
+	          outstr = outstr.replace(/]]>/g, ']]]]><![CDATA[>')
+	          writeString(outstr);
+	        });
+        }
+	      if (typeof screenshot != 'undefined') writeString('[[ATTACHMENT|' + screenshot + ']]\n');
+		    writeString(']]></system-out>\n');
+			}
+      
       writeString('</testcase>\n');
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mocha-jenkins-reporter",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "jenkins reporter for mocha",
   "main": "index.js",
   "directories": "./lib",


### PR DESCRIPTION
Changed the xml output for system out to only write one tag for log entries and the screenshot attachment because Jenkins JUnit plugin do only process the first system-out tag and ignore the second.
